### PR TITLE
Used @extends to prevent duplicated properties on compiled css.

### DIFF
--- a/lib/fluidity/semantic-grid.styl
+++ b/lib/fluidity/semantic-grid.styl
@@ -2,14 +2,17 @@ grid-width = 100% unless grid-width is defined
 grid-min-width = 960px unless grid-min-width is defined
 transition-speed = 300ms unless transition-speed is defined
 
-grid(width = grid-width, min-width = grid-min-width)
+$grid
   position relative
-  width width
-  min-width min-width
   margin 0 auto
   overflow hidden
   transform translate3d(0,0,0)
   transition left transition-speed linear
+
+grid(width = grid-width, min-width = grid-min-width)
+  @extends $grid
+  width width
+  min-width min-width
 
 section()
   display block
@@ -26,7 +29,7 @@ footer
 section
   section()
 
-space()
+$space
   display block
   position relative
   float left
@@ -36,7 +39,7 @@ space()
   box-sizing border-box
 
 grid-space(width)
-  space()
+  @extends $space
   width width
 
 center-space()


### PR DESCRIPTION
http://learnboost.github.io/stylus/docs/extend.html
